### PR TITLE
Added Card_Read_CustomFields to EndpointFactory

### DIFF
--- a/Manatee.Trello/Internal/DataAccess/EndpointFactory.cs
+++ b/Manatee.Trello/Internal/DataAccess/EndpointFactory.cs
@@ -45,6 +45,7 @@ namespace Manatee.Trello.Internal.DataAccess
 					{EntityRequestType.Card_Read_Actions, () => new Endpoint(RestMethod.Get, "cards", "_id", "actions")},
 					{EntityRequestType.Card_Read_Attachments, () => new Endpoint(RestMethod.Get, "cards", "_id", "attachments")},
 					{EntityRequestType.Card_Read_CheckLists, () => new Endpoint(RestMethod.Get, "cards", "_id", "checklists")},
+					{EntityRequestType.Card_Read_CustomFields, () => new Endpoint(RestMethod.Get, "card", "_id", "customFieldItems")},
 					{EntityRequestType.Card_Read_Labels, () => new Endpoint(RestMethod.Get, "cards", "_id", "labels")},
 					{EntityRequestType.Card_Read_Members, () => new Endpoint(RestMethod.Get, "cards", "_id", "members")},
 					{EntityRequestType.Card_Read_MembersVoted, () => new Endpoint(RestMethod.Get, "cards", "_id", "membersVoted")},


### PR DESCRIPTION
When calling
`await card.CustomFields.Refresh();`
I got an error. Looked into the code and added the required endpoint into the Endpoint Factory. Should be quite self explanatory.  Let me know if there's any questions